### PR TITLE
returns a formattable, locale-aware date string

### DIFF
--- a/user snippets/formattedDate.js
+++ b/user snippets/formattedDate.js
@@ -1,0 +1,26 @@
+/**
+ * Returns a flexibly formattable date string. Use when creating a variable via JavaScript.
+ * @param {object} - mablInputs Object containing input
+ *                   variables (mablInputs.variables.user)
+ * @param {function} callback - The callback function
+ */
+function mablJavaScriptStep(mablInputs, callback) {
+    // Set the number of days in the future of the target date.
+    let moreDays = 1;
+
+    // Set the locale for date translation and formatting.
+    // Examples:
+    // let locale = "de-DE";
+    // let locale = "fr-FR";
+    let locale = "en-US";
+
+    // Set date formatting options. Locale impacts final output.
+    // Examples:
+    // let options = { month: 'long', day: 'numeric' }; // Month DD
+    // let options = { month: '2-digit', day: '2-digit', year: '2-digit' }; // MM/DD/YY  
+    let options = {month: 'long', day: 'numeric', year: 'numeric'}; // Month DD, YYYY
+
+    const date = new Date();
+    date.setDate(date.getDate() + moreDays);
+    callback(date.toLocaleDateString(locale, options));
+}


### PR DESCRIPTION
handy when calculating a future date in a specific format or locale. useful in text input, but also when constructing selectors for date pickers that have element attributes with some portion of a date string, e.g. aria-label="March 13". speaks german, too.