### PR TITLE
New snippet to assert URL ends with a specified string

### DIFF
--- a/mabl snippets/assertPathEndsWith.js
+++ b/mabl snippets/assertPathEndsWith.js
@@ -1,0 +1,20 @@
+/**
+ * Verifies that the current page URL ends with the value stored
+ * in the variable 'endsWithString'.
+ * 
+ * @param {object} - mablInputs Object containing input
+ *                   variables (mablInputs.variables.user)
+ * @param {function} callback - The callback function
+ */
+function mablJavaScriptStep(mablInputs, callback) {
+  let endsWithString = mablInputs.variables.user.endsWithString;
+  if (!endsWithString) {
+    throw 'endsWithString variable must be defined';
+  }
+  
+  if (document.location.pathname.endsWith(endsWithString)) {
+    callback('Page URL ends with expected string');
+  } else {
+    throw 'Page URL ' + document.location.pathname + ' does not end with \'' + endsWithString + '\'';
+  }
+}


### PR DESCRIPTION
Implemented a snippet that verifies that the current page URL ends with the value of the variable stored in endsWith.