### PR TITLE
add networkCalls.js to user_snippets

### DIFF
--- a/user snippets/networkCalls.js
+++ b/user snippets/networkCalls.js
@@ -14,8 +14,9 @@
 
 function mablJavaScriptStep(mablInputs, callback) {
   // document.defaultView returns the window object in your browser
+  var window = document.defaultView;
   // document.defaultView.performance.getEntries() returns a list of all network calls made (works in latest Chrome and Firefox)
-  var networkCalls = document.defaultView.performance.getEntries();
+  var networkCalls = window.performance.getEntries();
 
   // code for checking network calls here
 

--- a/user snippets/networkCalls.js
+++ b/user snippets/networkCalls.js
@@ -1,0 +1,23 @@
+/**
+ * Run a small snippet of JavaScript during a mabl flow/journey
+ * 
+ * @param {object} mablInputs - Object containing mabl inputs such as variables (mablInputs.variables). 
+ *                              Use mablInputs.variables.user for user defined variables
+ *                              (For example myVar may be accessed as mablInputs.variables.user.myVar)
+ * 
+ * @param {function} callback - A callback function that must be called to complete 
+ *                              the javascript step and provide a value to the following 
+ *                              steps of the flow/journey. A return statement from this
+ *                              function call will not provide any results for use
+ *                              in the following steps in this flow or journey.
+ */
+
+function mablJavaScriptStep(mablInputs, callback) {
+  // document.defaultView returns the window object in your browser
+  // document.defaultView.performance.getEntries() returns a list of all network calls made (works in latest Chrome and Firefox)
+  const networkCalls = document.defaultView.performance.getEntries();
+
+  // code for checking network calls here
+
+  callback(1);
+}

--- a/user snippets/networkCalls.js
+++ b/user snippets/networkCalls.js
@@ -15,7 +15,7 @@
 function mablJavaScriptStep(mablInputs, callback) {
   // document.defaultView returns the window object in your browser
   // document.defaultView.performance.getEntries() returns a list of all network calls made (works in latest Chrome and Firefox)
-  const networkCalls = document.defaultView.performance.getEntries();
+  var networkCalls = document.defaultView.performance.getEntries();
 
   // code for checking network calls here
 

--- a/user snippets/networkCalls.js
+++ b/user snippets/networkCalls.js
@@ -1,5 +1,7 @@
 /**
- * Run a small snippet of JavaScript during a mabl flow/journey
+ * Demonstrates how to access the window object and how to access all network calls on a page visit via javascript.
+ * (NOTE: document.defaultView should work for Chrome, Firefox, and IE11,
+ * but document.defaultView.performance.getEntries only works for Chrome and Firefox)
  * 
  * @param {object} mablInputs - Object containing mabl inputs such as variables (mablInputs.variables). 
  *                              Use mablInputs.variables.user for user defined variables

--- a/user snippets/networkCalls.js
+++ b/user snippets/networkCalls.js
@@ -13,7 +13,7 @@
  */
 
 function mablJavaScriptStep(mablInputs, callback) {
-  // document.defaultView returns the window object in your browser
+  // document.defaultView returns the window object in your browser. mabl gives you access to document, but not window
   var window = document.defaultView;
   // document.defaultView.performance.getEntries() returns a list of all network calls made (works in latest Chrome and Firefox)
   var networkCalls = window.performance.getEntries();


### PR DESCRIPTION
add a snippet called networkCalls.js that shows users how to:
1. access the `window` object
2. access a list of network calls in Chrome and Firefox by using `document.defaultView.performance.getEntries()`