### PR TITLE
Wait until not present implementation

### DIFF
--- a/mabl snippets/waitUntilNotPresent.js
+++ b/mabl snippets/waitUntilNotPresent.js
@@ -1,0 +1,32 @@
+/**
+ * TITLE: Wait until the provided element is no longer present up to 15 seconds
+ *        testing every 100 ms
+ *
+ * @mablParam: elementSelector - A CSS selector for the element
+ *
+ * @mablReturn: 'true' if the element disappeared within the timeout,
+ *              'false' otherwise
+ *
+ */
+async function mablJavaScriptStep(mablInputs, callback) {
+  const TIME_BETWEEN_MS = 100;
+  const TIMEOUT_SEC = 15;
+  const MAX_RETRIES = TIMEOUT_SEC * 1000 / TIME_BETWEEN_MS;
+  
+  for (let i=0; i<MAX_RETRIES; i++) {
+    if (document.querySelector(mablInputs.variables.user.elementSelector) === null) {
+      callback(true);
+      break;
+    } else {
+      await delay(TIME_BETWEEN_MS);
+    }
+  }
+  
+  callback(false);
+}
+
+async function delay(millis) {
+  return new Promise(resolve => {
+    setTimeout(() => resolve(), millis);
+  });
+}

--- a/mabl snippets/waitUntilNotPresent.js
+++ b/mabl snippets/waitUntilNotPresent.js
@@ -1,6 +1,7 @@
 /**
  * TITLE: Wait until the provided element is no longer present up to 15 seconds
  *        testing every 100 ms
+ *        Note that this snippet will NOT work in Internet Explorer 11
  *
  * @mablParam: elementSelector - A CSS selector for the element
  *
@@ -13,6 +14,8 @@ async function mablJavaScriptStep(mablInputs, callback) {
   const TIMEOUT_SEC = 15;
   const MAX_RETRIES = TIMEOUT_SEC * 1000 / TIME_BETWEEN_MS;
   
+  // This loop will wait maximum 15 seconds for the provided CSS selector to
+  // disappear from the DOM.
   for (let i=0; i<MAX_RETRIES; i++) {
     if (document.querySelector(mablInputs.variables.user.elementSelector) === null) {
       callback(true);


### PR DESCRIPTION
Since we do not support waiting until an element disappears from the screen, I needed a snippet to do this in a dynamic fashion. This script tests the presence of an element identified by a CSS selector and checks the presence every 100 ms up to 15 seconds. If the element disappears, then the snippet returns true, otherwise - after 15 seconds - it will return false. 