### PR TITLE
Update insertText snippet to fire change events [MABL-3938]

### DIFF
--- a/mabl snippets/insertText.js
+++ b/mabl snippets/insertText.js
@@ -1,11 +1,11 @@
 /**
  * Run a small snippet of JavaScript during a mabl flow/journey
- * @param {object} mablInputs - Object containing mabl inputs such as variables (mablInputs.variables). 
+ * @param {object} mablInputs - Object containing mabl inputs such as variables (mablInputs.variables).
  *                              Use mablInputs.variables.user for user defined variables
  *                              (For example myVar may be accessed as mablInputs.variables.user.myVar)
- * 
- * @param {function} callback - A callback function that must be called to complete 
- *                              the javascript step and provide a value to the following 
+ *
+ * @param {function} callback - A callback function that must be called to complete
+ *                              the javascript step and provide a value to the following
  *                              steps of the flow/journey. A return statement from this
  *                              function call will not provide any results for use
  *                              in the following steps in this flow or journey.
@@ -15,14 +15,21 @@ function mablJavaScriptStep(mablInputs, callback) {
   // Gets the page element by ID
   let textbox = document.querySelector('#REPLACE_WITH_CSS_SELECTOR');
 
-  //check that the element is not null or undefined
+  // check that the element is not null or undefined
   if (!textbox) {
     throw Error('Element cannot be found');
   }
 
-  //click on textbox and insert text
+  // click on textbox and insert text
   textbox.value = "REPLACE_WITH_TEXT_TO_BE_INSERTED";
-  
+
+  // fire a change event
+  // some forms require specific change events so that the validation can work correctly.
+  // Consider using any of these events as well:
+  // ['focus', 'keydown', 'keypress', 'textInput', 'input', 'keyup', 'change', 'blur']
+  let event = new Event('input');
+  textbox.dispatchEvent(event);
+
   // text has been entered into textbox
   callback('Value has been inserted into textbox')
 }

--- a/mabl snippets/insertText.js
+++ b/mabl snippets/insertText.js
@@ -1,5 +1,6 @@
 /**
- * Run a small snippet of JavaScript during a mabl flow/journey
+ * This snippet finds a textbox element on the page,
+ * and inserts text into it by setting the value and firing a change event
  * @param {object} mablInputs - Object containing mabl inputs such as variables (mablInputs.variables).
  *                              Use mablInputs.variables.user for user defined variables
  *                              (For example myVar may be accessed as mablInputs.variables.user.myVar)
@@ -20,7 +21,7 @@ function mablJavaScriptStep(mablInputs, callback) {
     throw Error('Element cannot be found');
   }
 
-  // click on textbox and insert text
+  // insert text
   textbox.value = "REPLACE_WITH_TEXT_TO_BE_INSERTED";
 
   // fire a change event


### PR DESCRIPTION
I've seen a number of form fields that require change events (most of the time it's `input` events), so I think firing this `input` event by default would be helpful.