### PR TITLE
Adds snippet for scrolling through lazy loaded lists

### DIFF
--- a/mabl snippets/scrollLazyLoadedList.js
+++ b/mabl snippets/scrollLazyLoadedList.js
@@ -14,7 +14,7 @@ function mablJavaScriptStep(mablInputs, callback) {
     let loopCount = 0;
 
     // Call the "scrollDown" function once every half second
-    let scroll_interval = setInterval(scrollDown, 500);
+    let scrollInterval = setInterval(scrollDown, 500);
   
     // Function to be called to scroll down 
     function scrollDown() {
@@ -41,12 +41,12 @@ function mablJavaScriptStep(mablInputs, callback) {
       // Stop scrolling if the row was found and return
       if (elementTextFound) { 
         callback("Element Found")
-        clearInterval(scroll_interval);
+        clearInterval(scrollInterval);
       }
       // Stop scrolling if we have reached the bottom of the results and return
       if (scrolledToBottom) {
         callback("Element Not Found. Bottom of scroll view reached.")
-        clearInterval(scroll_interval);
+        clearInterval(scrollInterval);
       }
 >>>>>>> 9b635e7993add4f6ef0a247a6b401ae305b518d2
     }

--- a/mabl snippets/scrollLazyLoadedList.js
+++ b/mabl snippets/scrollLazyLoadedList.js
@@ -32,7 +32,7 @@ function mablJavaScriptStep(mablInputs, callback) {
       let matchingElements = allElements.filter(cell => cell.innerText.includes(elementText));
 
       // If the site name we were looking for was there, then there should be 1 value in the array (0 values otherwise)
-      let elementTextFound = matchingElements.length != 0;
+      let elementTextFound = matchingElements.length !== 0;
 
       // Determine if we have scrolled to the bottom of the scroll view
       let scrolledToBottom = table.scrollTop + table.offsetHeight === table.scrollHeight;

--- a/mabl snippets/scrollLazyLoadedList.js
+++ b/mabl snippets/scrollLazyLoadedList.js
@@ -1,0 +1,46 @@
+function mablJavaScriptStep(mablInputs, callback) {
+    // ## Values that one could parameterize ##
+    let scrollViewSelector = 'SELECTOR';
+    let elementSelector = 'SELECTOR';
+    let elementText = 'TEXT_OF_OPTION';
+  
+    // Find the scroll view
+    let table = document.querySelector(scrollViewSelector);
+
+    // Get the height of the number of cells that are loaded at a time
+    let loadedCellsHeight = table.offsetHeight;
+
+    // Call the "scrollDown" function once every half second
+    let scroll_interval = setInterval(scrollDown, 500);
+
+  
+    // Function to be called to scroll down 
+    function scrollDown() {
+
+      // Scroll down the table the height of the loaded cells * the number of times we have looped
+      table.scroll(0,loopCount * loadedCellsHeight);
+
+      // Get all the loaded site names
+      let allElements = Array.from(document.querySelectorAll(elementSelector));
+
+      // Find all the site names that contain the text in variable "elementText"
+      let matchingElements = allElements.filter(cell => cell.innerText.includes(elementText));
+
+      // If the site name we were looking for was there, then there should be 1 value in the array (0 values otherwise)
+      let elementTextFound = matchingElements.length != 0;
+
+      // Determine if we have scrolled to the bottom of the scroll view
+      let scrolledToBottom = table.scrollTop + table.offsetHeight == table.scrollHeight;
+      
+      // Stop scrolling if the row was found and return
+      if (elementTextFound) { 
+        callback("Element Found")
+        clearInterval(scroll_interval);
+      }
+      // Stop scrolling if we have reached the bottom of the results and return
+      if (scrolledToBottom) {
+        callback("Element Not Found. Bottom of scroll view reached.")
+        clearInterval(scroll_interval);
+      }
+    }
+  }

--- a/mabl snippets/scrollLazyLoadedList.js
+++ b/mabl snippets/scrollLazyLoadedList.js
@@ -1,53 +1,53 @@
 function mablJavaScriptStep(mablInputs, callback) {
-    // ## Values that one could parameterize ##
-    let scrollViewSelector = 'SELECTOR';
-    let elementSelector = 'SELECTOR';
-    let elementText = 'TEXT_OF_OPTION';
-  
-    // Find the scroll view
-    let table = document.querySelector(scrollViewSelector);
+  // ## Values that one could parameterize ##
+  let scrollViewSelector = "SELECTOR";
+  let elementSelector = "SELECTOR";
+  let elementText = "TEXT_OF_OPTION";
 
-    // Get the height of the number of cells that are loaded at a time
-    let loadedCellsHeight = table.offsetHeight;
+  // Find the scroll view
+  let table = document.querySelector(scrollViewSelector);
 
-    // Create a variable to keep track of the number of times the "scrollDown" function is called
-    let loopCount = 0;
+  // Get the height of the number of cells that are loaded at a time
+  let loadedCellsHeight = table.offsetHeight;
 
-    // Call the "scrollDown" function once every half second
-    let scrollInterval = setInterval(scrollDown, 500);
-  
-    // Function to be called to scroll down 
-    function scrollDown() {
+  // Create a variable to keep track of the number of times the "scrollDown" function is called
+  let loopCount = 0;
 
-      // Increase the value of variable "loopCount" by 1
-      ++loopCount;
+  // Call the "scrollDown" function once every half second
+  let scrollInterval = setInterval(scrollDown, 500);
 
-      // Scroll down the table the height of the loaded cells * the number of times we have looped
-      table.scroll(0,loopCount * loadedCellsHeight);
+  // Function to be called to scroll down
+  function scrollDown() {
+    // Increase the value of variable "loopCount" by 1
+    ++loopCount;
 
-      // Get all the loaded site names
-      let allElements = Array.from(document.querySelectorAll(elementSelector));
+    // Scroll down the table the height of the loaded cells * the number of times we have looped
+    table.scroll(0, loopCount * loadedCellsHeight);
 
-      // Find all the site names that contain the text in variable "elementText"
-      let matchingElements = allElements.filter(cell => cell.innerText.includes(elementText));
+    // Get all the loaded site names
+    let allElements = Array.from(document.querySelectorAll(elementSelector));
 
-      // If the site name we were looking for was there, then there should be 1 value in the array (0 values otherwise)
-      let elementTextFound = matchingElements.length !== 0;
+    // Find all the site names that contain the text in variable "elementText"
+    let matchingElements = allElements.filter((cell) =>
+      cell.innerText.includes(elementText)
+    );
 
-      // Determine if we have scrolled to the bottom of the scroll view
-      let scrolledToBottom = table.scrollTop + table.offsetHeight === table.scrollHeight;
+    // If the site name we were looking for was there, then there should be 1 value in the array (0 values otherwise)
+    let elementTextFound = matchingElements.length !== 0;
 
-      
-      // Stop scrolling if the row was found and return
-      if (elementTextFound) { 
-        callback("Element Found")
-        clearInterval(scrollInterval);
-      }
-      // Stop scrolling if we have reached the bottom of the results and return
-      if (scrolledToBottom) {
-        callback("Element Not Found. Bottom of scroll view reached.")
-        clearInterval(scrollInterval);
-      }
+    // Determine if we have scrolled to the bottom of the scroll view
+    let scrolledToBottom =
+      table.scrollTop + table.offsetHeight === table.scrollHeight;
+
+    // Stop scrolling if the row was found and return
+    if (elementTextFound) {
+      callback("Element Found");
+      clearInterval(scrollInterval);
+    }
+    // Stop scrolling if we have reached the bottom of the results and return
+    if (scrolledToBottom) {
+      callback("Element Not Found. Bottom of scroll view reached.");
+      clearInterval(scrollInterval);
     }
   }
 }

--- a/mabl snippets/scrollLazyLoadedList.js
+++ b/mabl snippets/scrollLazyLoadedList.js
@@ -1,3 +1,7 @@
+/**
+ * @NOTE - This is a snippet will not work in Internet Explorer.
+ */
+
 function mablJavaScriptStep(mablInputs, callback) {
   // ## Values that one could parameterize ##
   let scrollViewSelector = "SELECTOR";

--- a/mabl snippets/scrollLazyLoadedList.js
+++ b/mabl snippets/scrollLazyLoadedList.js
@@ -1,52 +1,53 @@
 function mablJavaScriptStep(mablInputs, callback) {
-    // ## Values that one could parameterize ##
-    let scrollViewSelector = 'SELECTOR';
-    let elementSelector = 'SELECTOR';
-    let elementText = 'TEXT_OF_OPTION';
-  
-    // Find the scroll view
-    let table = document.querySelector(scrollViewSelector);
+  // ## Values that one could parameterize ##
+  let scrollViewSelector = "SELECTOR";
+  let elementSelector = "SELECTOR";
+  let elementText = "TEXT_OF_OPTION";
 
-    // Get the height of the number of cells that are loaded at a time
-    let loadedCellsHeight = table.offsetHeight;
+  // Find the scroll view
+  let table = document.querySelector(scrollViewSelector);
 
-    // Create a variable to keep track of the number of times the "scrollDown" function is called
-    let loopCount = 0;
+  // Get the height of the number of cells that are loaded at a time
+  let loadedCellsHeight = table.offsetHeight;
 
-    // Call the "scrollDown" function once every half second
-    let scroll_interval = setInterval(scrollDown, 500);
-  
-    // Function to be called to scroll down 
-    function scrollDown() {
+  // Create a variable to keep track of the number of times the "scrollDown" function is called
+  let loopCount = 0;
 
-      // Increase the value of variable "loopCount" by 1
-      ++loopCount;
+  // Call the "scrollDown" function once every half second
+  let scrollInterval = setInterval(scrollDown, 500);
 
-      // Scroll down the table the height of the loaded cells * the number of times we have looped
-      table.scroll(0,loopCount * loadedCellsHeight);
+  // Function to be called to scroll down
+  function scrollDown() {
+    // Increase the value of variable "loopCount" by 1
+    ++loopCount;
 
-      // Get all the loaded site names
-      let allElements = Array.from(document.querySelectorAll(elementSelector));
+    // Scroll down the table the height of the loaded cells * the number of times we have looped
+    table.scroll(0, loopCount * loadedCellsHeight);
 
-      // Find all the site names that contain the text in variable "elementText"
-      let matchingElements = allElements.filter(cell => cell.innerText.includes(elementText));
+    // Get all the loaded site names
+    let allElements = Array.from(document.querySelectorAll(elementSelector));
 
-      // If the site name we were looking for was there, then there should be 1 value in the array (0 values otherwise)
-      let elementTextFound = matchingElements.length != 0;
+    // Find all the site names that contain the text in variable "elementText"
+    let matchingElements = allElements.filter((cell) =>
+      cell.innerText.includes(elementText)
+    );
 
-      // Determine if we have scrolled to the bottom of the scroll view
-      let scrolledToBottom = table.scrollTop + table.offsetHeight == table.scrollHeight;
+    // If the site name we were looking for was there, then there should be 1 value in the array (0 values otherwise)
+    let elementTextFound = matchingElements.length != 0;
 
-      
-      // Stop scrolling if the row was found and return
-      if (elementTextFound) { 
-        callback("Element Found")
-        clearInterval(scroll_interval);
-      }
-      // Stop scrolling if we have reached the bottom of the results and return
-      if (scrolledToBottom) {
-        callback("Element Not Found. Bottom of scroll view reached.")
-        clearInterval(scroll_interval);
-      }
+    // Determine if we have scrolled to the bottom of the scroll view
+    let scrolledToBottom =
+      table.scrollTop + table.offsetHeight == table.scrollHeight;
+
+    // Stop scrolling if the row was found and return
+    if (elementTextFound) {
+      callback("Element Found");
+      clearInterval(scrollInterval);
+    }
+    // Stop scrolling if we have reached the bottom of the results and return
+    if (scrolledToBottom) {
+      callback("Element Not Found. Bottom of scroll view reached.");
+      clearInterval(scrollInterval);
     }
   }
+}

--- a/mabl snippets/scrollLazyLoadedList.js
+++ b/mabl snippets/scrollLazyLoadedList.js
@@ -35,7 +35,7 @@ function mablJavaScriptStep(mablInputs, callback) {
       let elementTextFound = matchingElements.length != 0;
 
       // Determine if we have scrolled to the bottom of the scroll view
-      let scrolledToBottom = table.scrollTop + table.offsetHeight == table.scrollHeight;
+      let scrolledToBottom = table.scrollTop + table.offsetHeight === table.scrollHeight;
 
       
       // Stop scrolling if the row was found and return

--- a/mabl snippets/scrollLazyLoadedList.js
+++ b/mabl snippets/scrollLazyLoadedList.js
@@ -48,7 +48,6 @@ function mablJavaScriptStep(mablInputs, callback) {
         callback("Element Not Found. Bottom of scroll view reached.")
         clearInterval(scrollInterval);
       }
->>>>>>> 9b635e7993add4f6ef0a247a6b401ae305b518d2
     }
   }
 }

--- a/mabl snippets/scrollLazyLoadedList.js
+++ b/mabl snippets/scrollLazyLoadedList.js
@@ -10,12 +10,17 @@ function mablJavaScriptStep(mablInputs, callback) {
     // Get the height of the number of cells that are loaded at a time
     let loadedCellsHeight = table.offsetHeight;
 
+    // Create a variable to keep track of the number of times the "scrollDown" function is called
+    let loopCount = 0;
+
     // Call the "scrollDown" function once every half second
     let scroll_interval = setInterval(scrollDown, 500);
-
   
     // Function to be called to scroll down 
     function scrollDown() {
+
+      // Increase the value of variable "loopCount" by 1
+      ++loopCount;
 
       // Scroll down the table the height of the loaded cells * the number of times we have looped
       table.scroll(0,loopCount * loadedCellsHeight);
@@ -31,6 +36,7 @@ function mablJavaScriptStep(mablInputs, callback) {
 
       // Determine if we have scrolled to the bottom of the scroll view
       let scrolledToBottom = table.scrollTop + table.offsetHeight == table.scrollHeight;
+
       
       // Stop scrolling if the row was found and return
       if (elementTextFound) { 


### PR DESCRIPTION
Right now mabl will automatically scroll to any element that is found by our steps, but if an element is lazy loaded it doesn't exist in the DOM to scroll to it. This adds a snippet that handles scrolling down lazy loaded lists until the element if found that matches a specific innerText. 